### PR TITLE
Removed unused push handling from webhook

### DIFF
--- a/democrasite/settings.py
+++ b/democrasite/settings.py
@@ -13,8 +13,6 @@ https://docs.djangoproject.com/en/3.2/ref/settings/
 from pathlib import Path
 import environ
 
-# Build paths inside the project like this: BASE_DIR / 'subdir'.
-
 root = environ.Path(__file__) - 2
 env = environ.Env()
 try:
@@ -25,8 +23,6 @@ except FileNotFoundError:
 SITE_ROOT = root()
 
 
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/3.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env.str('SECRET_KEY')

--- a/elections/webhooks.py
+++ b/elections/webhooks.py
@@ -41,9 +41,6 @@ def github_hook(request):
             .get(social_auth__uid=userinfo['id'])
         return HttpResponse(f'{user.username} (id={user.id}, ' +
             f'id={userinfo["id"]}) is my favorite user')
-    elif event == 'push':
-        # Deploy some code for example
-        return HttpResponse('success')
     elif event == 'pull_request':
         process_pull.delay(payload['action'], payload['pull_request'])
         return HttpResponse('success')


### PR DESCRIPTION
I realized Heroku could handle the automatic redeployment whenever a change was pushed to Github, and there's no other processing I need to do when that happens, so I removed the if statement checking for that event.