### PR TITLE
Changed diff links from pull request conversation to pull request files

### DIFF
--- a/elections/templates/elections/bill_detail.html
+++ b/elections/templates/elections/bill_detail.html
@@ -20,7 +20,7 @@
           </a>
         {% endif %}
         <br>
-        <a class="git-pull-link" href="https://github.com/{{ github_repo }}/pull/{{ bill.pr_num }}" target="_blank">
+        <a class="git-pull-link" href="https://github.com/{{ github_repo }}/pull/{{ bill.pr_num }}/files" target="_blank">
           Diff:
           <span class="text-success">+{{ bill.additions }}</span>
           <span class="text-danger">-{{ bill.deletions }}</span>

--- a/elections/templates/elections/bill_list.html
+++ b/elections/templates/elections/bill_list.html
@@ -21,7 +21,7 @@
               {{ bill.description }}
             </div>
             <div class="card-text text-right">
-              <a class="card-link git-pull-link" href="https://github.com/{{ github_repo }}/pull/{{ bill.pr_num }}" target="_blank">
+              <a class="card-link git-pull-link" href="https://github.com/{{ github_repo }}/pull/{{ bill.pr_num }}/files" target="_blank">
                 <span class="text-success">+{{ bill.additions }}</span>
                 <span class="text-danger">-{{ bill.deletions }}</span>
               </a>


### PR DESCRIPTION
Change the diff links (the ones with green and red numbers on each bill) to point to the files updated by the pull request rather than the conversation so it's easier to see what changes are being proposed.