### PR TITLE
Changed webhook url

### DIFF
--- a/elections/urls.py
+++ b/elections/urls.py
@@ -20,5 +20,5 @@ urlpatterns = [
     path('bill/<int:pk>/vote', views.vote, name='bill-vote'),
     path('proposals/', views.BillProposalsView.as_view(), name='my-bills'),
     path('votes/', views.BillVotesView.as_view(), name='my-bill-votes'),
-    path('webhook/github/', github_hook),
+    path('hooks/github/', github_hook),
 ]


### PR DESCRIPTION
Changed the URL that's accessed by the Github Webhook (not visible to users) in order to make it consistent with Heroku's webhook URL. If this bill passes, I will update the settings on this repository to reflect the change.